### PR TITLE
Change button label to Sign up for new user

### DIFF
--- a/src/components/sing_in/SignInForm.tsx
+++ b/src/components/sing_in/SignInForm.tsx
@@ -113,6 +113,10 @@ export default function SignInForm({ setAuthenticating }: SignInFormProps) {
     }
   };
 
+  const getButtonLabel = () => {
+    return userType === UserType.NEW ? "Sign up with Google" : "Sign in with Google";
+  }
+
   return (
     <div className="sign-in-form">
       <div className="select-user-type label-large on-background-text">
@@ -138,7 +142,7 @@ export default function SignInForm({ setAuthenticating }: SignInFormProps) {
         id="signInButton"
       >
         {GoogleIcon}
-        Sign in with Google
+        {getButtonLabel()}
       </button>
       {getNotification()}
     </div>


### PR DESCRIPTION
When user selects **New user**, then button label is **Sign up with Google**.
When user selects **Existing user**, then button label is **Sign in with Google**.