### PR TITLE
Moved backend from AWS Elastic Beanstalk to Oracle OCI

### DIFF
--- a/src/services/config.json
+++ b/src/services/config.json
@@ -1,5 +1,5 @@
 {
-  "serviceEndpointUrl": "https://beta.messengerservice.rohitrai.dev/",
+  "serviceEndpointUrl": "https://prod.messengerservice.rohitrai.dev/",
   "headers": {
     "Content-Type": "application/json"
   }


### PR DESCRIPTION
As AWS Elastic Beanstalk is costing money, i have moved MessengerService Spring Boot deployment to Oracle OCI.